### PR TITLE
Add procurement order sheet panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,6 +246,23 @@
     Skylon Development © all rights reserved
    </p>
   </div>
+  <div id="procurement-panel" style="display:none; position:fixed; top:50%; left:50%; transform:translate(-50%,-50%); width:80%; max-width:800px; padding:20px; border:1px solid #555; background:#2d2d30; color:#f4f4f0; font-size:110%; max-height:80vh; overflow:auto; z-index:1001; border-radius:4px; box-shadow:0 4px 16px rgba(0,0,0,0.5);">
+   <h2>Procurement Materials Order Sheet</h2>
+   <table id="procurementTable" style="width:100%; border-collapse:collapse;">
+    <thead>
+     <tr>
+      <th style="text-align:left; padding:4px 8px; border-bottom:1px solid #555;">Item</th>
+      <th style="text-align:left; padding:4px 8px; border-bottom:1px solid #555;">Group</th>
+      <th style="text-align:left; padding:4px 8px; border-bottom:1px solid #555;">Start</th>
+      <th style="text-align:left; padding:4px 8px; border-bottom:1px solid #555;">End</th>
+     </tr>
+    </thead>
+    <tbody></tbody>
+   </table>
+   <div style="margin-top: 15px; text-align:right;">
+    <button onclick="toggleProcurement()">Close</button>
+   </div>
+  </div>
   <div class="container">
    <div class="header">
     <input class="project-title" id="projectTitle" type="text" value="3-7 Herbal - all 3 floors"/>
@@ -322,6 +339,9 @@
     </button>
     <button class="toolbar-btn" id="toggle-instructions" onclick="toggleInstructions()">
      📖 Instructions
+    </button>
+    <button class="toolbar-btn" onclick="toggleProcurement()">
+     Procurement
     </button>
     <button class="toolbar-btn" id="themeToggleBtn" onclick="toggleTheme()">
      <span id="themeIcon">☀️</span>

--- a/main.js
+++ b/main.js
@@ -326,6 +326,7 @@
         window.confirmEditMilestone = confirmEditMilestone;
         window.editMilestone = editMilestone;
         window.deleteMilestone = deleteMilestone;
+        window.toggleProcurement = toggleProcurement;
         
         // Theme management
         function loadTheme() {
@@ -2548,10 +2549,57 @@
         }
         
         // Initialize
-        window.toggleInstructions = function() {
-            const panel = document.getElementById('instructions-panel');
-            panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+       window.toggleInstructions = function() {
+           const panel = document.getElementById('instructions-panel');
+           panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+       };
+
+        window.toggleProcurement = function() {
+            const panel = document.getElementById('procurement-panel');
+            if (panel.style.display === 'none' || panel.style.display === '') {
+                generateProcurementList();
+                panel.style.display = 'block';
+            } else {
+                panel.style.display = 'none';
+            }
         };
+
+        function generateProcurementList() {
+            const tbody = document.querySelector('#procurementTable tbody');
+            if (!tbody) return;
+            tbody.innerHTML = '';
+
+            const formatter = date => formatDate(new Date(date));
+
+            allTasks.filter(t => /PO/i.test(t.name)).forEach(task => {
+                const row = document.createElement('tr');
+
+                const nameCell = document.createElement('td');
+                nameCell.textContent = task.name;
+                nameCell.style.padding = '4px 8px';
+                row.appendChild(nameCell);
+
+                const groupCell = document.createElement('td');
+                const groupName = availableGroups[task.group] ? availableGroups[task.group].name : task.group;
+                groupCell.textContent = groupName || '';
+                groupCell.style.padding = '4px 8px';
+                row.appendChild(groupCell);
+
+                const startCell = document.createElement('td');
+                const start = task.currentStart || task.start;
+                startCell.textContent = start ? formatter(start) : '';
+                startCell.style.padding = '4px 8px';
+                row.appendChild(startCell);
+
+                const endCell = document.createElement('td');
+                const end = task.currentEnd || task.end;
+                endCell.textContent = end ? formatter(end) : '';
+                endCell.style.padding = '4px 8px';
+                row.appendChild(endCell);
+
+                tbody.appendChild(row);
+            });
+        }
         
         loadConfiguration();
         loadCustomGroups();

--- a/styles.css
+++ b/styles.css
@@ -1588,6 +1588,24 @@
             box-shadow: 0 4px 16px rgba(0,0,0,0.1);
         }
 
+        /* Procurement panel light theme */
+        body.light-theme #procurement-panel {
+            background: #eae5db;
+            border-color: #c0bbb1;
+            color: #333333;
+            box-shadow: 0 4px 16px rgba(0,0,0,0.1);
+        }
+
+        #procurementTable th,
+        #procurementTable td {
+            border-bottom: 1px solid #555;
+        }
+
+        body.light-theme #procurementTable th,
+        body.light-theme #procurementTable td {
+            border-color: #c0bbb1;
+        }
+
         /* Radio buttons light theme */
         body.light-theme .radio-group label {
             color: #333333;


### PR DESCRIPTION
## Summary
- add toolbar button to open a Procurement order sheet
- show procurement tasks on a new panel
- style procurement panel for light theme
- switch list to table with task group and dates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68724df755488328ac24ddb1b7256c92